### PR TITLE
About issue of no auto connect if client refresh

### DIFF
--- a/weinre.web/modules/weinre/client/ConnectorList.coffee
+++ b/weinre.web/modules/weinre/client/ConnectorList.coffee
@@ -62,7 +62,8 @@ module.exports = class ConnectorList
         newest = 0
         for connectorChannel of @connectors
             continue if connectorChannel == ignoring
-            newest = connectorChannel if connectorChannel > newest
+            intValue = parseInt(connectorChannel.replace(/[^\d]+/, ''))
+            newest = connectorChannel if intValue > newest
 
         return null if newest == 0
         newest


### PR DESCRIPTION
If target refresh, then targetRegistered() of WeinreClientEventsImpl.coffee will do an auto connection for client and target.

If client refresh, then cb_getTargets() in RemotePanel.coffee will try to do auto connection. But in getNewestConnectorChannel() of ConnectorList.coffee which called from the previous function will always return null. 
That is because the variable connectorChannel will be like 't-1', 't-2', and will always return false in compare to newest(which have initial value 0). 

I fix this issue by filter the Non-Number characters, and do comparison after parse to integer. 

Thanks,
haibiao
