### PR TITLE
support HTTPS location for target script

### DIFF
--- a/weinre.web/modules/weinre/target/Target.coffee
+++ b/weinre.web/modules/weinre/target/Target.coffee
@@ -59,7 +59,7 @@ module.exports = class Target
         return if window.WeinreServerURL
 
         if element
-            pattern = /(http:\/\/(.*?)\/)/
+            pattern = /((https?:)?\/\/(.*?)\/)/
             match = pattern.exec(element.src)
             if match
                 window.WeinreServerURL = match[1]


### PR DESCRIPTION
Hi,

I have an HTTPS-only app that I need to test using Weinre. I set up an https proxy for Weinre, but I found that the client script itself did not recognize HTTPS addresses as valid server addresses. 

I wrote this small patch to allow the Weinre target script to better recognize HTTPS and protocol-agnostic addresses. I believe this change would be useful for other users of Weinre who need to test in HTTPS environments. Please let me know if you have any feedback on my proposed change.

Thanks
Sam Placette
