### PR TITLE
Add ignore-header feature

### DIFF
--- a/weinre.web/modules/weinre/target/HookSites.coffee
+++ b/weinre.web/modules/weinre/target/HookSites.coffee
@@ -32,6 +32,7 @@ HookSites.window_addEventListener         = HookLib.addHookSite window, "addEven
 HookSites.Node_addEventListener           = HookLib.addHookSite Node.prototype, "addEventListener"
 HookSites.XMLHttpRequest_open             = HookLib.addHookSite XMLHttpRequest.prototype, "open"
 HookSites.XMLHttpRequest_send             = HookLib.addHookSite XMLHttpRequest.prototype, "send"
+HookSites.XMLHttpRequest_setRequestHeader = HookLib.addHookSite XMLHttpRequest.prototype, "setRequestHeader"
 HookSites.XMLHttpRequest_addEventListener = HookLib.addHookSite XMLHttpRequest.prototype, "addEventListener"
 
 if window.openDatabase


### PR DESCRIPTION
This is ignore header feature.
The JavaScript whose "Weinre-Ignore" header is true will be ignored by Weinre.

```
$.ajax({
    url: "/",
    headers:{"Weinre-Ignore": true}
});
```

Then, we can make a web-platform layer including Weinre.
Platform developer can use XMLHttpRequest without showing it to platform user.
