### PR TITLE
CB-6991 Weinre fails to load in browsers without a built-in console

### DIFF
--- a/weinre.web/modules/weinre/target/Console.coffee
+++ b/weinre.web/modules/weinre/target/Console.coffee
@@ -168,7 +168,7 @@ module.exports = class Console
 
 #-------------------------------------------------------------------------------
 RemoteConsole   = new Console()
-OriginalConsole = window.console
+OriginalConsole = window.console or {}
 
 RemoteConsole.__original   = OriginalConsole
 OriginalConsole.__original = OriginalConsole


### PR DESCRIPTION
Weinre fails to load in browsers without a built-in development console
https://issues.apache.org/jira/browse/CB-6991
