### PR TITLE
Fix critical error in target device javascript

### DIFF
--- a/weinre.web/modules/weinre/common/WebSocketXhr.coffee
+++ b/weinre.web/modules/weinre/common/WebSocketXhr.coffee
@@ -201,7 +201,7 @@ module.exports = class WebSocketXhr
         xhr = (if XMLHttpRequest.noConflict then new XMLHttpRequest.noConflict() else new XMLHttpRequest())
         xhr.httpSocket = this
         xhr.httpSocketHandler = handler
-        xhr.onreadystatechange = _xhrEventHandler
+        xhr.onreadystatechange = _xhrEventHandler.bind(xhr)
 
         HookLib.ignoreHooks ->
             xhr.open method, url, true
@@ -213,7 +213,7 @@ module.exports = class WebSocketXhr
 
 #-------------------------------------------------------------------------------
 _xhrEventHandler = (event) ->
-      xhr = event.target
+      xhr = this
       return unless xhr.readyState == 4
 
       xhr.httpSocketHandler.call xhr.httpSocket, xhr


### PR DESCRIPTION
This fixes javascript errors which cause the script to fail and results in targets never finding the weinre server.

Due to use of `function.bind` this does not work in IE8 but inclusion of a polyfill would be simple if desired.
