### PR TITLE
simplify require logic for coffee-script and cli.coffee

### DIFF
--- a/weinre.server/weinre
+++ b/weinre.server/weinre
@@ -23,13 +23,5 @@
 
 // script to run the weinre server
 
-var path = require('path')
-var fs   = require('fs')
-
-var rootPath = path.dirname(fs.realpathSync(__filename))
-
-var lib          = path.join(rootPath, 'lib')
-var node_modules = path.join(rootPath, 'node_modules')
-
-require(path.join(node_modules, 'coffee-script'))
-require(path.join(lib, '/cli')).run()
+require('coffee-script')
+require('./lib/cli').run()


### PR DESCRIPTION
This is needed to make `npm dedupe` work with weinre
